### PR TITLE
bugfix for loss joint proj

### DIFF
--- a/main/model.py
+++ b/main/model.py
@@ -157,7 +157,7 @@ class Model(nn.Module):
 
             loss['joint_img'] = self.coord_loss(joint_img, targets['joint_img'], meta_info['joint_trunc'], meta_info['is_3D'])
             loss['mano_joint_img'] = torch.abs(joint_img - targets['mano_joint_img']) * meta_info['mano_joint_trunc']
-            loss['joint_proj'] = torch.abs(joint_proj - targets['joint_img'][:,:,:2]) * meta_info['joint_valid']
+            loss['joint_proj'] = torch.abs(joint_proj - targets['joint_img'][:,:,:2]) * meta_info['joint_trunc']
             return loss
         else:
             # cfg.output_hand_hm_shape -> cfg.input_img_shape


### PR DESCRIPTION
It seems that joint_proj loss uses the wrong weight(`meta["joint_valid"]`). When the detection box is inaccurate, some key points are outside the detection box. These points should not be supervised. The correct weight may be `meta["joint_trunc"]`
https://github.com/facebookresearch/InterWild/blob/1a0da99386f60fad7cba802d0188fcf6b9fff57f/main/model.py#L160